### PR TITLE
Fix: Move safeOutputLog to global scope to resolve undefined error

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -60,27 +60,29 @@ USER $USERNAME
 let outputChannel;
 
 /**
+ * Safe wrapper for output channel operations
+ */
+function safeOutputLog(message, show = false) {
+  try {
+    if (outputChannel) {
+      outputChannel.appendLine(message);
+      if (show) {
+        outputChannel.show();
+      }
+    }
+  } catch (error) {
+    // Silently ignore if output channel is disposed
+    console.log(`CodeForge: ${message}`);
+  }
+}
+
+/**
  * @param {vscode.ExtensionContext} context
  */
 function activate(context) {
   // Create output channel for CodeForge
   outputChannel = vscode.window.createOutputChannel("CodeForge");
   context.subscriptions.push(outputChannel);
-
-  // Safe wrapper for output channel operations
-  function safeOutputLog(message, show = false) {
-    try {
-      if (outputChannel) {
-        outputChannel.appendLine(message);
-        if (show) {
-          outputChannel.show();
-        }
-      }
-    } catch (error) {
-      // Silently ignore if output channel is disposed
-      console.log(`CodeForge: ${message}`);
-    }
-  }
 
   // Register the task provider
   try {


### PR DESCRIPTION
- Moved safeOutputLog function from inside activate() to module scope
- Fixes 'safeOutputLog is not defined' error during automatic initialization
- Makes function accessible to initializeCodeForgeOnActivation and ensureInitializedAndBuilt