### PR TITLE
feat: add CodeForge task registration command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,30 +17,53 @@ CodeForge is a VSCode extension that simplifies Docker container management dire
 
 Open the Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P` on macOS) and type "CodeForge" to see all available commands.
 
+### Quick Start: Register a Task
+
+The fastest way to get started with CodeForge tasks is to use the **`CodeForge: Register Task`** command:
+
+1. Open Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P`)
+2. Type `CodeForge: Register Task` and press Enter
+3. Enter your command (e.g., `npm test`, `python app.py`, `make build`)
+4. That's it! Your task is automatically registered and ready to use
+
+The command automatically:
+
+- Creates a properly formatted task with label `Run in CodeForge: [command]`
+- Adds a description `Run '[command]' in CodeForge container`
+- Saves it to `.vscode/tasks.json`
+- Offers to run the task immediately
+
+You can customize the generated task later by editing `.vscode/tasks.json` if needed.
+
 ### Available Commands
 
 1. `CodeForge: Initialize CodeForge` - Initialize CodeForge in your current workspace
 2. `CodeForge: Build Docker Environment` - Build the Docker environment based on your configuration
 3. `CodeForge: Launch Terminal in Container` - Open an interactive terminal in a Docker container
 4. `CodeForge: Run Command in Container` - Run a specific command inside a Docker container
+5. `CodeForge: Register Task` - **Recommended:** Quickly register a new CodeForge task
 
 ### Task Provider
 
 CodeForge includes a VSCode Task Provider that allows you to run commands inside Docker containers. This integrates seamlessly with VSCode's task system.
 
-#### Important: Task Configuration Required
+#### Quick Task Registration (Recommended)
 
-**CodeForge no longer provides default tasks.** You MUST configure your own tasks in `.vscode/tasks.json` with the required `"command"` property that specifies what to run in the Docker container.
+The easiest way to create CodeForge tasks is using the **`CodeForge: Register Task`** command:
 
-#### Using Tasks
+1. Open Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P`)
+2. Run `CodeForge: Register Task`
+3. Enter the command you want to run in the container (e.g., `npm test`, `make build`)
+4. The task is automatically created with:
+   - Label: `Run in CodeForge: [your command]`
+   - Description: `Run '[your command]' in CodeForge container`
+5. You'll be prompted to run the task immediately or can run it later via `Terminal → Run Task`
 
-1. **Configure Tasks**: Create a `.vscode/tasks.json` file with your CodeForge task definitions (required)
-2. **Execute Tasks**: Run tasks via `Terminal → Run Task` or keyboard shortcuts (`Ctrl+Shift+B` for build)
-3. **View Output**: Command output is captured in the CodeForge output window (View → Output → CodeForge)
+This command automatically creates or updates your `.vscode/tasks.json` file with the proper configuration. You can later edit `tasks.json` manually if you want to customize the labels, descriptions, or add additional properties like port mappings.
 
-#### Example Task Definition
+#### Manual Task Configuration
 
-Create a `.vscode/tasks.json` file in your project with the required `"command"` property:
+While using `CodeForge: Register Task` is recommended, you can also manually create or edit tasks in `.vscode/tasks.json`:
 
 ```json
 {
@@ -48,7 +71,7 @@ Create a `.vscode/tasks.json` file in your project with the required `"command"`
   "tasks": [
     {
       "type": "codeforge",
-      "label": "Run in Container: Build",
+      "label": "Run in CodeForge: Build",
       "command": "make build", // REQUIRED: Command to execute
       "detail": "Builds the project in Docker container",
       "group": {
@@ -58,7 +81,7 @@ Create a `.vscode/tasks.json` file in your project with the required `"command"`
     },
     {
       "type": "codeforge",
-      "label": "Run in Container: Test",
+      "label": "Run in CodeForge: Test",
       "command": "npm test", // REQUIRED: Command to execute
       "detail": "Runs tests in Docker container",
       "group": {
@@ -68,13 +91,13 @@ Create a `.vscode/tasks.json` file in your project with the required `"command"`
     },
     {
       "type": "codeforge",
-      "label": "Run in Container: Dev Server",
+      "label": "Run in CodeForge: Dev Server",
       "command": "npm run dev", // REQUIRED: Command to execute
       "detail": "Starts development server in Docker container"
     },
     {
       "type": "codeforge",
-      "label": "Run in Container: Web Server with Port Forwarding",
+      "label": "Run in CodeForge: Web Server with Port Forwarding",
       "command": "python -m http.server 8080", // REQUIRED: Command to execute
       "detail": "Starts a web server with port forwarding",
       "ports": ["8080:8080"] // Forward container port 8080 to host port 8080
@@ -83,7 +106,7 @@ Create a `.vscode/tasks.json` file in your project with the required `"command"`
 }
 ```
 
-**Note:** The `"command"` property is required for all tasks. Without it, the task will fail.
+**Note:** The `"command"` property is required for all tasks. Without it, the task will fail. For quick task creation, use the `CodeForge: Register Task` command instead of manually editing this file.
 
 ### Port Forwarding
 

--- a/examples/tasks.json
+++ b/examples/tasks.json
@@ -10,7 +10,7 @@
     // Example 1: Build a C/C++ project using Make
     {
       "type": "codeforge",
-      "label": "Run in Container: Build Project",
+      "label": "Run in CodeForge: Build Project",
       "command": "make build", // REQUIRED: The command to run in the container
       "detail": "Builds the project using make in the Docker container",
       "group": {
@@ -23,7 +23,7 @@
     // Example 2: Run Python tests with pytest
     {
       "type": "codeforge",
-      "label": "Run in Container: Python Tests",
+      "label": "Run in CodeForge: Python Tests",
       "command": "python3 -m pytest tests/ -v", // REQUIRED: Command to execute
       "detail": "Runs Python tests with verbose output in the Docker container",
       "group": {
@@ -35,7 +35,7 @@
     // Example 3: Run a Node.js development server
     {
       "type": "codeforge",
-      "label": "Run in Container: Dev Server",
+      "label": "Run in CodeForge: Dev Server",
       "command": "npm run dev", // REQUIRED: The npm script to run
       "detail": "Starts the development server in the Docker container",
       "problemMatcher": []
@@ -44,7 +44,7 @@
     // Example 4: Clean build artifacts
     {
       "type": "codeforge",
-      "label": "Run in Container: Clean",
+      "label": "Run in CodeForge: Clean",
       "command": "make clean && rm -rf build/", // Can chain multiple commands
       "detail": "Cleans build artifacts and removes build directory"
     },
@@ -52,7 +52,7 @@
     // Example 5: Run code linter
     {
       "type": "codeforge",
-      "label": "Run in Container: Lint Code",
+      "label": "Run in CodeForge: Lint Code",
       "command": "eslint src/**/*.js --fix", // REQUIRED: Linting command
       "detail": "Runs ESLint on JavaScript files and auto-fixes issues",
       "problemMatcher": {
@@ -72,7 +72,7 @@
     // Example 6: Format code with prettier
     {
       "type": "codeforge",
-      "label": "Run in Container: Format Code",
+      "label": "Run in CodeForge: Format Code",
       "command": "prettier --write '**/*.{js,jsx,ts,tsx,json,css,md}'",
       "detail": "Formats code files using Prettier"
     },
@@ -80,7 +80,7 @@
     // Example 7: Database migration
     {
       "type": "codeforge",
-      "label": "Run in Container: Database Migration",
+      "label": "Run in CodeForge: Database Migration",
       "command": "npm run migrate:latest", // REQUIRED: Migration command
       "detail": "Runs database migrations to latest version"
     },
@@ -88,7 +88,7 @@
     // Example 8: Generate documentation
     {
       "type": "codeforge",
-      "label": "Run in Container: Generate Docs",
+      "label": "Run in CodeForge: Generate Docs",
       "command": "jsdoc -c jsdoc.json -r src/ -d docs/api",
       "detail": "Generates API documentation from source code"
     },
@@ -96,7 +96,7 @@
     // Example 9: Run security audit
     {
       "type": "codeforge",
-      "label": "Run in Container: Security Audit",
+      "label": "Run in CodeForge: Security Audit",
       "command": "npm audit --production", // REQUIRED: Audit command
       "detail": "Checks for security vulnerabilities in dependencies"
     },
@@ -104,7 +104,7 @@
     // Example 10: Custom shell script
     {
       "type": "codeforge",
-      "label": "Run in Container: Custom Build Script",
+      "label": "Run in CodeForge: Custom Build Script",
       "command": "./scripts/build.sh --production", // REQUIRED: Script path
       "detail": "Runs a custom build script with production flag",
       "options": {
@@ -115,7 +115,7 @@
     // Example 11: Install dependencies
     {
       "type": "codeforge",
-      "label": "Run in Container: Install Dependencies",
+      "label": "Run in CodeForge: Install Dependencies",
       "command": "npm ci", // REQUIRED: Install command
       "detail": "Installs project dependencies from package-lock.json"
     },
@@ -123,7 +123,7 @@
     // Example 12: Run integration tests
     {
       "type": "codeforge",
-      "label": "Run in Container: Integration Tests",
+      "label": "Run in CodeForge: Integration Tests",
       "command": "npm run test:integration -- --coverage",
       "detail": "Runs integration tests with code coverage report",
       "group": "test"

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "onCommand:codeforge.buildEnvironment",
     "onCommand:codeforge.launchTerminal",
     "onCommand:codeforge.runCommand",
+    "onCommand:codeforge.registerTask",
     "onCommand:codeforge.listContainers",
     "onCommand:codeforge.terminateAllContainers",
     "onCommand:codeforge.cleanupOrphaned",
@@ -72,6 +73,10 @@
       {
         "command": "codeforge.runCommand",
         "title": "CodeForge: Run Command in Container"
+      },
+      {
+        "command": "codeforge.registerTask",
+        "title": "CodeForge: Register Task"
       },
       {
         "command": "codeforge.listContainers",

--- a/taskProvider.js
+++ b/taskProvider.js
@@ -40,21 +40,6 @@ class CodeForgeTaskProvider {
           'echo "Hello from CodeForge! Configure your tasks in .vscode/tasks.json"',
       },
     );
-
-    // IMPORTANT: Users should configure their own tasks in .vscode/tasks.json
-    // Example tasks.json configuration:
-    // {
-    //     "version": "2.0.0",
-    //     "tasks": [
-    //         {
-    //             "type": "codeforge",
-    //             "label": "Run in Container",
-    //             "command": "your-command-here",
-    //             "problemMatcher": []
-    //         }
-    //     ]
-    // }
-
     return [sampleTask];
   }
 


### PR DESCRIPTION
- Add new codeforge.registerTask command handler in extension.js
- Update package.json with command registration and activation event
- Add comprehensive documentation in README.md for task registration
- Update examples/tasks.json with improved task examples
- Clean up redundant code in taskProvider.js

This feature allows users to register and manage CodeForge tasks directly from the VS Code command palette, improving the developer experience for task management within the extension.