### PR TITLE
feat: add test case count tracking and display for fuzzers

### DIFF
--- a/src/ui/webview.css
+++ b/src/ui/webview.css
@@ -586,6 +586,17 @@ body {
   font-weight: 600;
 }
 
+.test-count {
+  color: var(--vscode-descriptionForeground);
+  font-size: 11px;
+  background-color: var(--vscode-badge-background);
+  color: var(--vscode-badge-foreground);
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
 .fuzzer-preset {
   color: var(--vscode-descriptionForeground);
   font-size: 12px;

--- a/src/ui/webview.js
+++ b/src/ui/webview.js
@@ -424,6 +424,8 @@
     const crashText = crashCount === 1 ? "crash" : "crashes";
     // Use displayName from backend (formatted by fuzzerUtils) or fallback to name
     const displayName = fuzzer.displayName || fuzzer.name;
+    const testCount = fuzzer.testCount || 0;
+    const formattedTestCount = formatTestCount(testCount);
 
     // Render crashes as collapsible sub-items
     let crashItems = "";
@@ -478,6 +480,7 @@
         <div class="fuzzer-header">
           <div class="fuzzer-info">
             <span class="fuzzer-name">${displayName}</span>
+            ${testCount > 0 ? `<span class="test-count" title="${testCount} test cases executed">${formattedTestCount}</span>` : ""}
           </div>
         </div>
         ${crashSection}
@@ -560,6 +563,13 @@
       console.warn("Failed to format crash date:", error);
       return "Invalid date";
     }
+  }
+
+  function formatTestCount(count) {
+    if (count === 0) return "0";
+    if (count < 1000) return count.toString();
+    if (count < 1000000) return (count / 1000).toFixed(1) + "k";
+    return (count / 1000000).toFixed(1) + "M";
   }
 
   // Initialize with initial state if available

--- a/test/suite/fuzzer-discovery.test.js
+++ b/test/suite/fuzzer-discovery.test.js
@@ -121,13 +121,13 @@ another-invalid-line
   test("should get correct fuzzer output directory", function () {
     const result = fuzzerDiscoveryService.getFuzzerOutputDirectory(
       testWorkspacePath,
-      "example-fuzz",
+      "codeforge-example-fuzz",
     );
     const expected = path.join(
       testWorkspacePath,
       ".codeforge",
       "fuzzing",
-      "codeforge-example-fuzz-fuzz-output",
+      "codeforge-example-fuzz-output",
     );
     assert.strictEqual(result, expected);
   });


### PR DESCRIPTION
- Update run-fuzz-tests.sh to extract and store test counts per fuzzer
- Add test count accumulation across runs in fuzzer output directories
- Implement getTestCount() method to read counts from test-count.txt files
- Display test counts as badges next to fuzzer names in activity panel
- Add formatTestCount() to show human-readable numbers (e.g., 1.2k, 2.5M)
- Fix fuzzer output directory path to match actual structure