### PR TITLE
feat: add ability to run individual fuzzers from activity panel

### DIFF
--- a/src/ui/webview.js
+++ b/src/ui/webview.js
@@ -484,6 +484,7 @@
             ${testCount > 0 ? `<span class="test-count" title="${testCount} test cases executed">${formattedTestCount}</span>` : ""}
           </div>
           <div class="fuzzer-actions">
+            <button class="fuzzer-action-btn" data-action="runFuzzer" data-fuzzer-name="${fuzzer.name}" title="Run this fuzzer">▶️</button>
             <button class="fuzzer-action-btn" data-action="viewCorpus" data-fuzzer-name="${fuzzer.name}" title="View corpus files">📁</button>
           </div>
         </div>
@@ -493,6 +494,16 @@
   }
 
   function addFuzzerEventListeners() {
+    // Run fuzzer buttons
+    document
+      .querySelectorAll('.fuzzer-action-btn[data-action="runFuzzer"]')
+      .forEach((btn) => {
+        btn.addEventListener("click", (e) => {
+          const fuzzerName = e.target.dataset.fuzzerName;
+          executeCommand("runFuzzer", { fuzzerName });
+        });
+      });
+
     // View corpus buttons
     document
       .querySelectorAll('.fuzzer-action-btn[data-action="viewCorpus"]')

--- a/src/ui/webviewProvider.js
+++ b/src/ui/webviewProvider.js
@@ -146,6 +146,7 @@ class CodeForgeWebviewProvider {
         refreshContainers: "codeforge.refreshContainers",
         refreshFuzzers: "codeforge.refreshFuzzers",
         refreshCrashes: "codeforge.refreshFuzzers", // Backward compatibility
+        runFuzzer: "codeforge.runFuzzer",
         viewCrash: "codeforge.viewCrash",
         analyzeCrash: "codeforge.analyzeCrash",
         clearCrashes: "codeforge.clearCrashes",


### PR DESCRIPTION
Add a run button to each fuzzer in the activity panel that allows users to run a specific fuzzer without running all fuzzers. This improves workflow by allowing targeted fuzzing of individual components.

Changes:
- Add handleRunFuzzer command handler to execute a single fuzzer
- Extend CodeForgeFuzzingTerminal to support running specific fuzzers
- Add runSpecificFuzzer method that discovers, builds, and runs one fuzzer
- Add run button to fuzzer headers in webview UI
- Wire up webview command mapping for runFuzzer command
- Add comprehensive test coverage for new functionality

The implementation leverages existing fuzzing infrastructure and reuses the build and run scripts with single fuzzer targets.