### PR TITLE
feat: integrate clear-crashes.sh script with fuzzer activity panel

### DIFF
--- a/resources/scripts/clear-crashes.sh
+++ b/resources/scripts/clear-crashes.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# This script finds the crash hashes for a given fuzz test (or all of them)
+
+scripts_directory="$(dirname "$(realpath "$0")")"
+codeforge_directory="$(realpath "$scripts_directory/..")"
+root_directory="$(realpath "$codeforge_directory/..")"
+fuzzing_directory="$codeforge_directory/fuzzing"
+
+cd "$root_directory"
+
+if [ $# -gt 0 ]; then
+    fuzzers="$1"
+else 
+    fuzzers=$($scripts_directory/find-fuzz-tests.sh -q)
+fi
+
+for f in $fuzzers; do
+    IFS=":" read -r preset fuzzer_name <<< "$f"
+
+    output_dir="$fuzzing_directory/$fuzzer_name-output"
+
+    if [[ ! -d "$output_dir" ]]; then
+        continue
+    fi
+
+    rm -f ${output_dir}/crash-*
+    rm -f ${output_dir}/backtrace-*
+    rm -f ${output_dir}/test-count.txt
+done

--- a/src/core/resourceManager.js
+++ b/src/core/resourceManager.js
@@ -131,6 +131,7 @@ class ResourceManager {
         "build-fuzz-tests.sh",
         "find-fuzz-tests.sh",
         "run-fuzz-tests.sh",
+        "clear-crashes.sh",
       ];
       const dumpedPaths = [];
 

--- a/src/ui/webview.js
+++ b/src/ui/webview.js
@@ -542,13 +542,7 @@
     document.querySelectorAll(".clear-all-btn").forEach((btn) => {
       btn.addEventListener("click", (e) => {
         const fuzzerName = e.target.dataset.fuzzer;
-        if (
-          confirm(
-            `Are you sure you want to clear all crashes for ${fuzzerName}?`,
-          )
-        ) {
-          executeCommand("clearCrashes", { fuzzerName });
-        }
+        executeCommand("clearCrashes", { fuzzerName });
       });
     });
   }

--- a/test/utils/activity-bar-test-helpers.js
+++ b/test/utils/activity-bar-test-helpers.js
@@ -745,6 +745,17 @@ function createFuzzerDiscoveryServiceMocks(sandbox) {
     updateFuzzerStatus: sandbox.stub().resolves(),
     associateCrashesWithFuzzers: sandbox.stub().returns([]),
     refreshFuzzerData: sandbox.stub().resolves(createMockFuzzerData()),
+    getCachedFuzzer: sandbox.stub().callsFake((fuzzerName) => {
+      // Return a mock fuzzer with preset
+      return {
+        name: fuzzerName,
+        preset: "libfuzzer",
+        crashes: [],
+        lastUpdated: new Date(),
+        outputDir: `/test/workspace/.codeforge/fuzzing/${fuzzerName}-output`,
+        testCount: 100,
+      };
+    }),
   };
 
   // Try to stub the actual module if it exists


### PR DESCRIPTION
- Add clear-crashes.sh script to clear crash files for fuzzers
- Update resourceManager to include clear-crashes.sh in dumpScripts
- Refactor handleClearCrashes to use Docker script execution instead of manual fs operations
- Pass fuzzer identifier in preset:fuzzer_name format to script
- Get fuzzer preset from fuzzerDiscoveryService cache
- Remove confirmation dialog from clear crashes button in webview
- Update all tests to mock Docker operations instead of filesystem
- Add getCachedFuzzer mock to fuzzer discovery service mocks
- Add test coverage for preset format, cache misses, and error handling
- Update resource manager tests to include clear-crashes.sh mock