### PR TITLE
fix: improve terminal error handling, refresh behavior, and crash fil…

### DIFF
--- a/src/fuzzing/fuzzingTerminal.js
+++ b/src/fuzzing/fuzzingTerminal.js
@@ -57,7 +57,14 @@ class CodeForgeFuzzingTerminal {
         const message =
           'CodeForge: Dockerfile not found. Please run "CodeForge: Initialize CodeForge" first.';
         this.writeEmitter.fire(`\r\n\x1b[33m${message}\x1b[0m\r\n`);
-        this.closeEmitter.fire(1);
+
+        // Mark fuzzing as complete (failed) and enable key-to-close
+        this.fuzzingComplete = true;
+
+        // Add message prompting user to press any key to close
+        this.writeEmitter.fire(
+          `\r\n\x1b[93mPress any key to close terminal...\x1b[0m\r\n`,
+        );
         return;
       }
 
@@ -79,7 +86,14 @@ class CodeForgeFuzzingTerminal {
         } catch (error) {
           const errorMessage = `Failed to build Docker image: ${error.message}`;
           this.writeEmitter.fire(`\r\n\x1b[31m${errorMessage}\x1b[0m\r\n`);
-          this.closeEmitter.fire(1);
+
+          // Mark fuzzing as complete (failed) and enable key-to-close
+          this.fuzzingComplete = true;
+
+          // Add message prompting user to press any key to close
+          this.writeEmitter.fire(
+            `\r\n\x1b[93mPress any key to close terminal...\x1b[0m\r\n`,
+          );
           return;
         }
       }
@@ -143,12 +157,26 @@ class CodeForgeFuzzingTerminal {
       } catch (error) {
         const errorMessage = `Fuzzing failed: ${error.message}`;
         this.writeEmitter.fire(`\r\n\x1b[31m${errorMessage}\x1b[0m\r\n`);
-        this.closeEmitter.fire(1);
+
+        // Mark fuzzing as complete (failed) and enable key-to-close
+        this.fuzzingComplete = true;
+
+        // Add message prompting user to press any key to close
+        this.writeEmitter.fire(
+          `\r\n\x1b[93mPress any key to close terminal...\x1b[0m\r\n`,
+        );
       }
     } catch (error) {
       const errorMessage = `Error: ${error.message}`;
       this.writeEmitter.fire(`\r\n\x1b[31m${errorMessage}\x1b[0m\r\n`);
-      this.closeEmitter.fire(1);
+
+      // Mark fuzzing as complete (failed) and enable key-to-close
+      this.fuzzingComplete = true;
+
+      // Add message prompting user to press any key to close
+      this.writeEmitter.fire(
+        `\r\n\x1b[93mPress any key to close terminal...\x1b[0m\r\n`,
+      );
     }
   }
 
@@ -341,7 +369,14 @@ class CodeForgeBuildTerminal {
         const message =
           'CodeForge: Dockerfile not found. Please run "CodeForge: Initialize CodeForge" first.';
         this.writeEmitter.fire(`\r\n\x1b[33m${message}\x1b[0m\r\n`);
-        this.closeEmitter.fire(1);
+
+        // Mark build as complete (failed) and enable key-to-close
+        this.buildComplete = true;
+
+        // Add message prompting user to press any key to close
+        this.writeEmitter.fire(
+          `\r\n\x1b[93mPress any key to close terminal...\x1b[0m\r\n`,
+        );
         return;
       }
 
@@ -363,7 +398,14 @@ class CodeForgeBuildTerminal {
         } catch (error) {
           const errorMessage = `Failed to build Docker image: ${error.message}`;
           this.writeEmitter.fire(`\r\n\x1b[31m${errorMessage}\x1b[0m\r\n`);
-          this.closeEmitter.fire(1);
+
+          // Mark build as complete (failed) and enable key-to-close
+          this.buildComplete = true;
+
+          // Add message prompting user to press any key to close
+          this.writeEmitter.fire(
+            `\r\n\x1b[93mPress any key to close terminal...\x1b[0m\r\n`,
+          );
           return;
         }
       }
@@ -418,12 +460,26 @@ class CodeForgeBuildTerminal {
         };
 
         this.displayBuildFailure(error);
-        this.closeEmitter.fire(1);
+
+        // Mark build as complete (failed) and enable key-to-close
+        this.buildComplete = true;
+
+        // Add message prompting user to press any key to close
+        this.writeEmitter.fire(
+          `\r\n\x1b[93mPress any key to close terminal...\x1b[0m\r\n`,
+        );
       }
     } catch (error) {
       const errorMessage = `Error: ${error.message}`;
       this.writeEmitter.fire(`\r\n\x1b[31m${errorMessage}\x1b[0m\r\n`);
-      this.closeEmitter.fire(1);
+
+      // Mark build as complete (failed) and enable key-to-close
+      this.buildComplete = true;
+
+      // Add message prompting user to press any key to close
+      this.writeEmitter.fire(
+        `\r\n\x1b[93mPress any key to close terminal...\x1b[0m\r\n`,
+      );
     }
   }
 

--- a/src/ui/commandHandlers.js
+++ b/src/ui/commandHandlers.js
@@ -861,9 +861,9 @@ class CodeForgeCommandHandlers {
         this.webviewProvider._setFuzzerLoading(true);
       }
 
-      // Discover fuzzers with associated crashes
+      // Refresh fuzzers with associated crashes (bypasses cache)
       const imageName = dockerOperations.generateContainerName(workspacePath);
-      const fuzzerData = await this.fuzzerDiscoveryService.discoverFuzzers(
+      const fuzzerData = await this.fuzzerDiscoveryService.refreshFuzzerData(
         workspacePath,
         imageName,
       );

--- a/src/ui/webview.js
+++ b/src/ui/webview.js
@@ -108,7 +108,25 @@
   // Update UI state
   function updateState(newState) {
     console.log("Updating state:", newState);
-    currentState = { ...currentState, ...newState };
+    // Deep merge for nested objects to prevent state accumulation issues
+    if (newState.fuzzers) {
+      currentState.fuzzers = {
+        isLoading: newState.fuzzers.isLoading ?? currentState.fuzzers.isLoading,
+        lastUpdated:
+          newState.fuzzers.lastUpdated ?? currentState.fuzzers.lastUpdated,
+        data: newState.fuzzers.data ?? currentState.fuzzers.data,
+        error: newState.fuzzers.error ?? currentState.fuzzers.error,
+      };
+    }
+    if (newState.initialization) {
+      currentState.initialization = {
+        ...currentState.initialization,
+        ...newState.initialization,
+      };
+    }
+    if (newState.isLoading !== undefined) {
+      currentState.isLoading = newState.isLoading;
+    }
     updateUI();
   }
 
@@ -378,6 +396,9 @@
 
     const { fuzzers } = currentState;
 
+    // Clear content first to prevent duplication
+    elements.fuzzersContent.innerHTML = "";
+
     if (fuzzers.isLoading) {
       elements.fuzzersContent.innerHTML = `
         <div class="fuzzers-loading">
@@ -410,11 +431,13 @@
       return;
     }
 
-    // Render fuzzer data
+    // Render fuzzer data - build complete HTML string first
     let html = "";
     fuzzers.data.forEach((fuzzer) => {
       html += renderFuzzerItem(fuzzer);
     });
+
+    // Set innerHTML once with complete HTML
     elements.fuzzersContent.innerHTML = html;
 
     // Add event listeners for fuzzer and crash actions

--- a/test/suite/command-handlers.test.js
+++ b/test/suite/command-handlers.test.js
@@ -561,13 +561,13 @@ suite("Command Handlers Test Suite", () => {
     test("handleRefreshFuzzers should discover and update fuzzer data", async () => {
       // Mock successful fuzzer discovery
       const mockFuzzerData = createMockFuzzerData();
-      testEnvironment.fuzzerMocks.discoverFuzzers.resolves(mockFuzzerData);
+      testEnvironment.fuzzerMocks.refreshFuzzerData.resolves(mockFuzzerData);
 
       await commandHandlers.handleRefreshFuzzers();
 
       assert.ok(
-        testEnvironment.fuzzerMocks.discoverFuzzers.called,
-        "Should call discoverFuzzers",
+        testEnvironment.fuzzerMocks.refreshFuzzerData.called,
+        "Should call refreshFuzzerData to bypass cache",
       );
       assert.ok(
         mockWebviewProvider._updateFuzzerState.called,
@@ -581,13 +581,13 @@ suite("Command Handlers Test Suite", () => {
 
     test("handleRefreshFuzzers should handle no fuzzers found", async () => {
       // Mock empty fuzzer discovery
-      testEnvironment.fuzzerMocks.discoverFuzzers.resolves([]);
+      testEnvironment.fuzzerMocks.refreshFuzzerData.resolves([]);
 
       await commandHandlers.handleRefreshFuzzers();
 
       assert.ok(
-        testEnvironment.fuzzerMocks.discoverFuzzers.called,
-        "Should call discoverFuzzers",
+        testEnvironment.fuzzerMocks.refreshFuzzerData.called,
+        "Should call refreshFuzzerData to bypass cache",
       );
       assert.ok(
         mockWebviewProvider._updateFuzzerState.called,
@@ -613,7 +613,7 @@ suite("Command Handlers Test Suite", () => {
     test("handleRefreshFuzzers should handle errors", async () => {
       // Mock fuzzer discovery error
       const errorMessage = "Permission denied";
-      testEnvironment.fuzzerMocks.discoverFuzzers.rejects(
+      testEnvironment.fuzzerMocks.refreshFuzzerData.rejects(
         new Error(errorMessage),
       );
 
@@ -1608,7 +1608,7 @@ suite("Command Handlers Test Suite", () => {
     test("Should handle complete fuzzer workflow", async () => {
       // 1. Refresh fuzzers
       const mockFuzzerData = createMockFuzzerData();
-      testEnvironment.fuzzerMocks.discoverFuzzers.resolves(mockFuzzerData);
+      testEnvironment.fuzzerMocks.refreshFuzzerData.resolves(mockFuzzerData);
 
       await commandHandlers.handleRefreshFuzzers();
 
@@ -1686,7 +1686,7 @@ suite("Command Handlers Test Suite", () => {
 
     test("Should handle concurrent fuzzer operations", async () => {
       const mockFuzzerData = createMockFuzzerData();
-      testEnvironment.fuzzerMocks.discoverFuzzers.resolves(mockFuzzerData);
+      testEnvironment.fuzzerMocks.refreshFuzzerData.resolves(mockFuzzerData);
 
       // Execute multiple operations concurrently
       const promises = [
@@ -1701,7 +1701,7 @@ suite("Command Handlers Test Suite", () => {
       await Promise.all(promises);
 
       assert.ok(
-        testEnvironment.fuzzerMocks.discoverFuzzers.called,
+        testEnvironment.fuzzerMocks.refreshFuzzerData.called,
         "Should handle refresh operation",
       );
     });
@@ -1720,17 +1720,17 @@ suite("Command Handlers Test Suite", () => {
         },
       ];
 
-      // The fuzzerDiscoveryService.discoverFuzzers is already stubbed by setupTestEnvironment
+      // The fuzzerDiscoveryService.refreshFuzzerData is already stubbed by setupTestEnvironment
       // Just configure it to return our mock data
-      commandHandlers.fuzzerDiscoveryService.discoverFuzzers.resolves(
+      commandHandlers.fuzzerDiscoveryService.refreshFuzzerData.resolves(
         mockFuzzerData,
       );
 
       await commandHandlers.handleRefreshFuzzers();
 
       assert.ok(
-        commandHandlers.fuzzerDiscoveryService.discoverFuzzers.called,
-        "Should call discoverFuzzers",
+        commandHandlers.fuzzerDiscoveryService.refreshFuzzerData.called,
+        "Should call refreshFuzzerData to bypass cache",
       );
     });
   });


### PR DESCRIPTION
…e viewing

- Keep terminal open on fuzzer build errors with key-to-close prompt
- Fix refresh button to bypass cache and always fetch fresh data
- Resolve fuzzer/crash duplication in UI during refresh
- Fix crash viewer to handle large files without hitting VSCode 50MB limit

Changes:
- Terminal now displays errors and waits for user input before closing
- Refresh button calls refreshFuzzerData() instead of discoverFuzzers()
- Clear DOM before rendering and use explicit state property assignment
- Read only needed bytes (64KB) from crash files instead of entire file
- Add tests for terminal error handling behavior