### PR TITLE
feat: add regenerate fuzzer list command and fix output channel auto-…

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "onCommand:codeforge.cleanupOrphaned",
     "onCommand:codeforge.runFuzzingTests",
     "onCommand:codeforge.buildFuzzingTests",
+    "onCommand:codeforge.regenerateFuzzerList",
     "onView:codeforge.controlPanel",
     "onView:codeforge.activeContainers",
     "workspaceContains:.codeforge/Dockerfile",
@@ -165,6 +166,11 @@
         "command": "codeforge.buildFuzzingTests",
         "title": "CodeForge: Build Fuzzing Tests",
         "icon": "$(tools)"
+      },
+      {
+        "command": "codeforge.regenerateFuzzerList",
+        "title": "CodeForge: Regenerate Fuzzer List",
+        "icon": "$(refresh)"
       }
     ],
     "menus": {


### PR DESCRIPTION
…show

- Add new command 'codeforge.regenerateFuzzerList' to command palette
- Implement handleRegenerateFuzzerList() to call find-fuzz-tests.sh with -c flag
- Add comprehensive test coverage for the new command
- Fix output channel auto-show behavior across all commands:
  - handleRunFuzzer: no longer auto-shows output when starting fuzzer
  - handleDebugCrash: no longer auto-shows output for GDB connection info
  - handleClearCrashes: no longer auto-shows output when clearing crashes
  - handleRegenerateFuzzerList: logs without auto-showing output
- Output channel now only auto-shows for errors or user-requested actions

The regenerate command clears the cached fuzzer list and regenerates it from CMake presets, then refreshes the UI with updated fuzzer data.