### PR TITLE
fix: add initialization check to fuzzer refresh command

### DIFF
--- a/src/ui/commandHandlers.js
+++ b/src/ui/commandHandlers.js
@@ -858,16 +858,29 @@ class CodeForgeCommandHandlers {
     try {
       const { path: workspacePath } = this.getWorkspaceInfo();
 
+      // Check initialization and build status
+      const containerName =
+        dockerOperations.generateContainerName(workspacePath);
+      const initialized = await this.ensureInitializedAndBuilt(
+        workspacePath,
+        containerName,
+      );
+      if (!initialized) {
+        vscode.window.showInformationMessage(
+          "CodeForge: Fuzzer refresh cancelled - project initialization and Docker build required",
+        );
+        return;
+      }
+
       // Set loading state
       if (this.webviewProvider) {
         this.webviewProvider._setFuzzerLoading(true);
       }
 
       // Refresh fuzzers with associated crashes (bypasses cache)
-      const imageName = dockerOperations.generateContainerName(workspacePath);
       const fuzzerData = await this.fuzzerDiscoveryService.refreshFuzzerData(
         workspacePath,
-        imageName,
+        containerName,
       );
 
       // Update state


### PR DESCRIPTION
Prevents Docker image error when running "Find fuzzers" before project initialization. The handleRefreshFuzzers method now checks if CodeForge is initialized and the Docker image is built before attempting to discover fuzzers.

Changes:
- Add ensureInitializedAndBuilt check to handleRefreshFuzzers
- Show user-friendly message when initialization is required
- Add comprehensive tests for initialization check behavior
- Update existing tests to properly mock initialization