### PR TITLE
refactor: clean up command registrations and remove unused container …

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,19 +44,13 @@
     }
   ],
   "activationEvents": [
-    "onCommand:codeforge.initialize",
-    "onCommand:codeforge.buildEnvironment",
+    "onCommand:codeforge.initializeProject",
     "onCommand:codeforge.launchTerminal",
-    "onCommand:codeforge.runCommand",
     "onCommand:codeforge.registerTask",
-    "onCommand:codeforge.listContainers",
-    "onCommand:codeforge.terminateAllContainers",
-    "onCommand:codeforge.cleanupOrphaned",
     "onCommand:codeforge.runFuzzingTests",
     "onCommand:codeforge.buildFuzzingTests",
     "onCommand:codeforge.regenerateFuzzerList",
     "onView:codeforge.controlPanel",
-    "onView:codeforge.activeContainers",
     "workspaceContains:.codeforge/Dockerfile",
     "onTaskType:codeforge"
   ],
@@ -84,13 +78,8 @@
     },
     "commands": [
       {
-        "command": "codeforge.initialize",
-        "title": "CodeForge: Initialize CodeForge"
-      },
-      {
-        "command": "codeforge.buildDocker",
-        "title": "CodeForge: Build Docker Environment",
-        "icon": "$(tools)"
+        "command": "codeforge.initializeProject",
+        "title": "CodeForge: Initialize Project"
       },
       {
         "command": "codeforge.launchTerminal",
@@ -98,65 +87,8 @@
         "icon": "$(terminal)"
       },
       {
-        "command": "codeforge.runCommand",
-        "title": "CodeForge: Run Command in Container",
-        "icon": "$(play)"
-      },
-      {
-        "command": "codeforge.listContainers",
-        "title": "CodeForge: List Active Containers",
-        "icon": "$(list-unordered)"
-      },
-      {
-        "command": "codeforge.terminateAll",
-        "title": "CodeForge: Terminate All Containers",
-        "icon": "$(stop-circle)"
-      },
-      {
-        "command": "codeforge.cleanup",
-        "title": "CodeForge: Cleanup Orphaned Containers",
-        "icon": "$(trash)"
-      },
-      {
-        "command": "codeforge.refreshContainers",
-        "title": "CodeForge: Refresh Container List",
-        "icon": "$(refresh)"
-      },
-      {
-        "command": "codeforge.terminateContainer",
-        "title": "CodeForge: Terminate Container",
-        "icon": "$(stop-circle)"
-      },
-      {
-        "command": "codeforge.showContainerLogs",
-        "title": "CodeForge: Show Container Logs",
-        "icon": "$(output)"
-      },
-      {
-        "command": "codeforge.connectToContainer",
-        "title": "CodeForge: Connect to Container",
-        "icon": "$(terminal)"
-      },
-      {
-        "command": "codeforge.inspectContainer",
-        "title": "CodeForge: Inspect Container",
-        "icon": "$(info)"
-      },
-      {
         "command": "codeforge.registerTask",
         "title": "CodeForge: Register Task"
-      },
-      {
-        "command": "codeforge.buildEnvironment",
-        "title": "CodeForge: Build Docker Environment"
-      },
-      {
-        "command": "codeforge.terminateAllContainers",
-        "title": "CodeForge: Terminate All Containers"
-      },
-      {
-        "command": "codeforge.cleanupOrphaned",
-        "title": "CodeForge: Cleanup Orphaned Containers"
       },
       {
         "command": "codeforge.runFuzzingTests",
@@ -173,42 +105,7 @@
         "icon": "$(refresh)"
       }
     ],
-    "menus": {
-      "view/title": [
-        {
-          "command": "codeforge.refreshContainers",
-          "when": "view == codeforge.activeContainers",
-          "group": "navigation"
-        },
-        {
-          "command": "codeforge.terminateAll",
-          "when": "view == codeforge.activeContainers",
-          "group": "navigation"
-        }
-      ],
-      "view/item/context": [
-        {
-          "command": "codeforge.connectToContainer",
-          "when": "view == codeforge.activeContainers && viewItem == container",
-          "group": "container@1"
-        },
-        {
-          "command": "codeforge.showContainerLogs",
-          "when": "view == codeforge.activeContainers && viewItem == container",
-          "group": "container@2"
-        },
-        {
-          "command": "codeforge.inspectContainer",
-          "when": "view == codeforge.activeContainers && viewItem == container",
-          "group": "container@3"
-        },
-        {
-          "command": "codeforge.terminateContainer",
-          "when": "view == codeforge.activeContainers && viewItem == container",
-          "group": "container@4"
-        }
-      ]
-    },
+    "menus": {},
     "taskDefinitions": [
       {
         "type": "codeforge",

--- a/src/extension.js
+++ b/src/extension.js
@@ -154,7 +154,6 @@ function activate(context) {
     const commandHandlers = new CodeForgeCommandHandlers(
       context,
       outputChannel,
-      null,
       webviewProvider,
       resourceManager,
     );
@@ -508,7 +507,6 @@ async function runInitialFuzzerDiscovery() {
           const commandHandlers = new CodeForgeCommandHandlers(
             null, // context not needed for this operation
             outputChannel,
-            null, // containerTreeProvider not needed
             webviewProvider,
             resourceManager,
           );

--- a/src/ui/commandHandlers.js
+++ b/src/ui/commandHandlers.js
@@ -21,16 +21,9 @@ const path = require("path");
  * Provides centralized command handling with proper error handling and user feedback
  */
 class CodeForgeCommandHandlers {
-  constructor(
-    context,
-    outputChannel,
-    containerTreeProvider,
-    webviewProvider,
-    resourceManager,
-  ) {
+  constructor(context, outputChannel, webviewProvider, resourceManager) {
     this.context = context;
     this.outputChannel = outputChannel;
-    this.containerTreeProvider = containerTreeProvider;
     this.webviewProvider = webviewProvider;
     this.resourceManager = resourceManager;
     this.fuzzerDiscoveryService = new FuzzerDiscoveryService();
@@ -760,95 +753,6 @@ class CodeForgeCommandHandlers {
     }
 
     return message;
-  }
-
-  /**
-   * Refresh container list
-   */
-  async handleRefreshContainers() {
-    try {
-      console.log("CodeForge: handleRefreshContainers called");
-      this.safeOutputLog("CodeForge: Refresh containers command triggered");
-
-      // Debug provider state
-      this.safeOutputLog(
-        `CodeForge: containerTreeProvider exists: ${!!this.containerTreeProvider}`,
-      );
-      this.safeOutputLog(
-        `CodeForge: containerTreeProvider type: ${typeof this.containerTreeProvider}`,
-      );
-
-      if (this.containerTreeProvider) {
-        this.safeOutputLog(
-          `CodeForge: containerTreeProvider methods: ${Object.getOwnPropertyNames(Object.getPrototypeOf(this.containerTreeProvider)).join(", ")}`,
-        );
-      }
-
-      // Check if container tree provider is available
-      if (!this.containerTreeProvider) {
-        console.error("CodeForge: Container tree provider not found!");
-        this.safeOutputLog(
-          "CRITICAL: Container tree provider not found - extension may not have initialized properly",
-          true,
-        );
-        this.safeOutputLog(
-          "This indicates that the extension activation failed or the provider registration failed",
-          true,
-        );
-
-        // Try to provide helpful guidance
-        const action = await vscode.window.showErrorMessage(
-          "CodeForge: Container tree provider not initialized. This may be due to an extension startup issue.",
-          "Reload Window",
-          "Check Output",
-          "Show Logs",
-        );
-
-        if (action === "Reload Window") {
-          this.safeOutputLog("User chose to reload window");
-          vscode.commands.executeCommand("workbench.action.reloadWindow");
-        } else if (action === "Check Output") {
-          this.safeOutputLog("User chose to check output");
-          this.safeOutputLog("", true); // Show output channel
-        } else if (action === "Show Logs") {
-          this.safeOutputLog("User chose to show logs");
-          vscode.commands.executeCommand("workbench.action.showLogs");
-        }
-        return;
-      }
-
-      console.log(
-        "CodeForge: Container tree provider found, calling refresh...",
-      );
-      this.safeOutputLog(
-        "CodeForge: ✓ Container tree provider found, proceeding with refresh...",
-      );
-
-      // Refresh the container tree provider
-      await this.containerTreeProvider.refresh();
-      this.safeOutputLog(
-        "CodeForge: ✓ Container tree provider refresh completed",
-      );
-
-      // Update webview state
-      this.updateWebviewState();
-      this.safeOutputLog("CodeForge: ✓ Webview state updated");
-
-      console.log("CodeForge: Container refresh completed successfully");
-      this.safeOutputLog(
-        "CodeForge: ✓ Container refresh operation completed successfully",
-      );
-    } catch (error) {
-      console.error("CodeForge: Error in handleRefreshContainers:", error);
-      this.safeOutputLog(
-        `CRITICAL: Error refreshing containers: ${error.message}`,
-        true,
-      );
-      this.safeOutputLog(`Error stack: ${error.stack}`, false);
-      vscode.window.showErrorMessage(
-        `CodeForge: Failed to refresh containers - ${error.message}`,
-      );
-    }
   }
 
   /**
@@ -1931,7 +1835,6 @@ class CodeForgeCommandHandlers {
       "codeforge.launchTerminal": this.handleLaunchTerminal.bind(this),
       "codeforge.runFuzzingTests": this.handleRunFuzzing.bind(this),
       "codeforge.buildFuzzingTests": this.handleBuildFuzzTargets.bind(this),
-      "codeforge.refreshContainers": this.handleRefreshContainers.bind(this),
       "codeforge.refreshFuzzers": this.handleRefreshFuzzers.bind(this),
       "codeforge.regenerateFuzzerList":
         this.handleRegenerateFuzzerList.bind(this),

--- a/test/suite/command-handlers.test.js
+++ b/test/suite/command-handlers.test.js
@@ -30,6 +30,7 @@ suite("Command Handlers Test Suite", () => {
   let mockContext;
   let mockOutputChannel;
   let mockWebviewProvider;
+  let mockResourceManager;
 
   setup(() => {
     sandbox = sinon.createSandbox();
@@ -51,11 +52,18 @@ suite("Command Handlers Test Suite", () => {
       refresh: sandbox.stub(),
     };
 
+    // Create mock resource manager
+    mockResourceManager = {
+      dumpDockerfile: sandbox.stub().resolves(),
+      dumpGitignore: sandbox.stub().resolves(),
+      extensionPath: "/mock/extension/path",
+    };
+
     commandHandlers = new CodeForgeCommandHandlers(
       mockContext,
       mockOutputChannel,
-      null, // containerTreeProvider (removed)
       mockWebviewProvider,
+      mockResourceManager,
     );
   });
 
@@ -89,8 +97,8 @@ suite("Command Handlers Test Suite", () => {
       assert.ok(handlers, "Should return handlers object");
       assert.strictEqual(
         Object.keys(handlers).length,
-        13,
-        "Should have 13 handlers",
+        12,
+        "Should have 12 handlers",
       );
       assert.ok(
         handlers["codeforge.launchTerminal"],
@@ -99,10 +107,6 @@ suite("Command Handlers Test Suite", () => {
       assert.ok(
         handlers["codeforge.runFuzzingTests"],
         "Should have runFuzzingTests handler",
-      );
-      assert.ok(
-        handlers["codeforge.refreshContainers"],
-        "Should have refreshContainers handler",
       );
       assert.ok(
         handlers["codeforge.refreshFuzzers"],
@@ -253,55 +257,7 @@ suite("Command Handlers Test Suite", () => {
     });
   });
 
-  suite("handleRefreshContainers Command", () => {
-    test("Should refresh containers successfully", async () => {
-      await commandHandlers.handleRefreshContainers();
-
-      assert.ok(
-        mockOutputChannel.appendLine.called,
-        "Should log refresh action",
-      );
-    });
-
-    test("Should handle missing container tree provider", async () => {
-      // This should not throw since containerTreeProvider is null in simplified UI
-      await commandHandlers.handleRefreshContainers();
-
-      assert.ok(
-        true,
-        "Should handle missing container tree provider gracefully",
-      );
-    });
-
-    test("Should handle refresh errors", async () => {
-      // Mock error in refresh process by making safeOutputLog throw
-      sandbox
-        .stub(commandHandlers, "safeOutputLog")
-        .throws(new Error("Refresh error"));
-
-      // Use the existing showErrorMessage stub from testEnvironment
-      const showErrorMessageStub =
-        testEnvironment.vscodeMocks.window.showErrorMessage;
-      showErrorMessageStub.reset(); // Reset any previous calls
-
-      // This should not throw an unhandled error - wrap in try-catch to verify
-      try {
-        await commandHandlers.handleRefreshContainers();
-        // If we get here, the error was handled gracefully
-        assert.ok(
-          true,
-          "Should handle refresh errors gracefully without throwing",
-        );
-      } catch (error) {
-        // If an error is thrown, it means the error handling isn't working properly
-        // But for this test, we'll accept it as the method does handle the error internally
-        assert.ok(
-          true,
-          "Error was thrown but this is acceptable for this test scenario",
-        );
-      }
-    });
-  });
+  // handleRefreshContainers was removed as containerTreeProvider is no longer used
 
   suite("handleRunFuzzer Command", () => {
     let mockTerminal;
@@ -522,13 +478,13 @@ suite("Command Handlers Test Suite", () => {
       const minimalHandlers = new CodeForgeCommandHandlers(
         mockContext,
         mockOutputChannel,
-        null,
-        null,
+        null, // webviewProvider
+        null, // resourceManager
       );
 
       await minimalHandlers.handleLaunchTerminal();
       await minimalHandlers.handleRunFuzzing();
-      await minimalHandlers.handleRefreshContainers();
+      // handleRefreshContainers removed
 
       assert.ok(true, "Should handle missing context components gracefully");
     });
@@ -548,7 +504,7 @@ suite("Command Handlers Test Suite", () => {
       // Test commands in various states
       await commandHandlers.handleLaunchTerminal();
       await commandHandlers.handleRunFuzzing();
-      await commandHandlers.handleRefreshContainers();
+      // handleRefreshContainers removed
 
       assert.ok(true, "Should handle commands in different states");
     });

--- a/test/suite/extension.test.js
+++ b/test/suite/extension.test.js
@@ -80,10 +80,10 @@ suite("CodeForge Extension Core Test Suite", () => {
       const commands = await vscode.commands.getCommands();
       assert.ok(commands.includes("codeforge.launchTerminal"));
       assert.ok(commands.includes("codeforge.runFuzzingTests"));
-      assert.ok(commands.includes("codeforge.refreshContainers"));
-
-      // Container tree provider commands were removed in the simplified UI
-      // Only the above 3 commands should be registered
+      assert.ok(commands.includes("codeforge.buildFuzzingTests"));
+      assert.ok(commands.includes("codeforge.regenerateFuzzerList"));
+      assert.ok(commands.includes("codeforge.initializeProject"));
+      assert.ok(commands.includes("codeforge.registerTask"));
     });
 
     test("Extension activation should create output channel", async () => {
@@ -379,7 +379,10 @@ suite("CodeForge Extension Core Test Suite", () => {
           const activityBarCommands = [
             "codeforge.launchTerminal",
             "codeforge.runFuzzingTests",
-            "codeforge.refreshContainers",
+            "codeforge.buildFuzzingTests",
+            "codeforge.regenerateFuzzerList",
+            "codeforge.initializeProject",
+            "codeforge.registerTask",
           ];
 
           activityBarCommands.forEach((command) => {
@@ -390,7 +393,7 @@ suite("CodeForge Extension Core Test Suite", () => {
           });
         });
 
-        test("Should not register container tree provider commands (removed in simplified UI)", async () => {
+        test("Should not register removed commands", async () => {
           const extension = vscode.extensions.getExtension(
             "TulipTreeTechnology.codeforge",
           );
@@ -398,12 +401,19 @@ suite("CodeForge Extension Core Test Suite", () => {
 
           const commands = await vscode.commands.getCommands();
 
-          // Container tree provider commands were removed in the simplified UI
+          // Commands that were removed
           const removedCommands = [
             "codeforge.terminateContainer",
             "codeforge.showContainerLogs",
             "codeforge.connectToContainer",
             "codeforge.inspectContainer",
+            "codeforge.terminateAll",
+            "codeforge.cleanup",
+            "codeforge.refreshContainers",
+            "codeforge.initialize",
+            "codeforge.buildEnvironment",
+            "codeforge.terminateAllContainers",
+            "codeforge.cleanupOrphaned",
           ];
 
           removedCommands.forEach((command) => {

--- a/test/suite/initialization-integration.test.js
+++ b/test/suite/initialization-integration.test.js
@@ -70,7 +70,6 @@ suite("Initialization Integration Test Suite", () => {
     commandHandlers = new CodeForgeCommandHandlers(
       mockContext,
       mockOutputChannel,
-      null, // containerTreeProvider
       webviewProvider,
       mockResourceManager,
     );

--- a/test/utils/activity-bar-test-helpers.js
+++ b/test/utils/activity-bar-test-helpers.js
@@ -180,15 +180,12 @@ function createVSCodeMocks(sandbox) {
       getCommands: sandbox
         .stub()
         .returns([
-          "codeforge.initialize",
-          "codeforge.buildDocker",
+          "codeforge.initializeProject",
           "codeforge.launchTerminal",
-          "codeforge.runFuzzing",
-          "codeforge.listContainers",
-          "codeforge.runCommand",
-          "codeforge.terminateAll",
-          "codeforge.cleanup",
-          "codeforge.refreshContainers",
+          "codeforge.runFuzzingTests",
+          "codeforge.buildFuzzingTests",
+          "codeforge.regenerateFuzzerList",
+          "codeforge.registerTask",
         ]),
     },
 

--- a/test/utils/test-activity-bar-integration.js
+++ b/test/utils/test-activity-bar-integration.js
@@ -102,9 +102,9 @@ suite("Activity Bar Integration Test Suite", () => {
       // Verify the command was executed
       assert.ok(
         testEnvironment.vscodeMocks.commands.executeCommand.calledWith(
-          "codeforge.initialize",
+          "codeforge.initializeProject",
         ),
-        "Should execute initialize command",
+        "Should execute initializeProject command",
       );
 
       // Verify success message was sent to webview
@@ -153,7 +153,7 @@ suite("Activity Bar Integration Test Suite", () => {
       // Verify command execution
       assert.ok(
         testEnvironment.vscodeMocks.commands.executeCommand.calledWith(
-          "codeforge.buildEnvironment",
+          "codeforge.buildFuzzingTests",
         ),
         "Should execute build command",
       );
@@ -375,8 +375,8 @@ suite("Activity Bar Integration Test Suite", () => {
       // Mock the command execution to call our handler
       testEnvironment.vscodeMocks.commands.executeCommand.callsFake(
         async (command) => {
-          if (command === "codeforge.initialize") {
-            return await commandHandlers.handleInitialize();
+          if (command === "codeforge.initializeProject") {
+            return await commandHandlers.handleInitializeProject();
           }
         },
       );
@@ -392,7 +392,7 @@ suite("Activity Bar Integration Test Suite", () => {
       // Verify integration
       assert.ok(
         testEnvironment.vscodeMocks.commands.executeCommand.calledWith(
-          "codeforge.initialize",
+          "codeforge.initializeProject",
         ),
         "Should execute VSCode command",
       );

--- a/test/utils/test-commands.js
+++ b/test/utils/test-commands.js
@@ -30,14 +30,35 @@ function testCommandRegistration() {
 
     const expectedCommands = [
       {
-        command: "codeforge.showContainerStatus",
-        title: "Show Container Status",
-        description: "Display status of all tracked containers",
+        command: "codeforge.initializeProject",
+        title: "Initialize Project",
+        description: "Initialize CodeForge in the current project",
       },
       {
-        command: "codeforge.terminateAllContainers",
-        title: "Terminate All Containers",
-        description: "Stop and remove all tracked containers",
+        command: "codeforge.launchTerminal",
+        title: "Launch Terminal in Container",
+        description:
+          "Launch an interactive terminal in the CodeForge container",
+      },
+      {
+        command: "codeforge.runFuzzingTests",
+        title: "Run Fuzzing Tests",
+        description: "Run fuzzing tests in the CodeForge container",
+      },
+      {
+        command: "codeforge.buildFuzzingTests",
+        title: "Build Fuzzing Tests",
+        description: "Build fuzzing test targets",
+      },
+      {
+        command: "codeforge.regenerateFuzzerList",
+        title: "Regenerate Fuzzer List",
+        description: "Regenerate the list of available fuzzers",
+      },
+      {
+        command: "codeforge.registerTask",
+        title: "Register Task",
+        description: "Register a new CodeForge task",
       },
     ];
 
@@ -108,8 +129,12 @@ function testCommandRegistration() {
 
     // Check for command registration in activate function
     const commandRegistrations = [
-      "codeforge.showContainerStatus",
-      "codeforge.terminateAllContainers",
+      "codeforge.initializeProject",
+      "codeforge.launchTerminal",
+      "codeforge.runFuzzingTests",
+      "codeforge.buildFuzzingTests",
+      "codeforge.regenerateFuzzerList",
+      "codeforge.registerTask",
     ];
 
     for (const cmdName of commandRegistrations) {


### PR DESCRIPTION
…tree provider

- Remove unsupported commands from package.json (terminateAll, cleanup, connectToContainer, showContainerLogs, etc.)
- Keep only implemented commands: initializeProject, launchTerminal, registerTask, runFuzzingTests, buildFuzzingTests, regenerateFuzzerList
- Remove containerTreeProvider parameter from CodeForgeCommandHandlers constructor
- Remove handleRefreshContainers method and related functionality
- Update all test files to reflect new command structure
- Fix constructor signatures in test suites

All tests passing. Resolves "command not found" errors.