### PR TITLE
fix: resolve GDB remote debugging threading and stack trace errors

### DIFF
--- a/resources/scripts/generate-backtrace.sh
+++ b/resources/scripts/generate-backtrace.sh
@@ -14,9 +14,9 @@ cd "$root_directory"
 if [ $# -lt 1 ]; then
     exit 1
 fi
-crash="$1"
+fuzzer_and_crash_hash="$1"
 
-IFS="/" read -r fuzzer_name crash_hash <<< "$crash"
+IFS="/" read -r fuzzer_name crash_hash <<< "$fuzzer_and_crash_hash"
 
 output_dir="$fuzzing_directory/$fuzzer_name-output"
 backtrace_output_file=$output_dir/backtrace-$crash_hash.txt

--- a/src/fuzzing/gdbIntegration.js
+++ b/src/fuzzing/gdbIntegration.js
@@ -409,7 +409,8 @@ class GdbServerLauncher {
 
     // Build gdbserver command
     // gdbserver listens on all interfaces (0.0.0.0) inside the container
-    const gdbserverCommand = `gdbserver 0.0.0.0:${containerPort} ${containerFuzzerPath} ${containerCrashPath}`;
+    // Use --once to exit after one debugging session
+    const gdbserverCommand = `gdbserver --once 0.0.0.0:${containerPort} ${containerFuzzerPath} ${containerCrashPath}`;
 
     // Prepare Docker run options with port forwarding
     const dockerArgs = [

--- a/src/ui/commandHandlers.js
+++ b/src/ui/commandHandlers.js
@@ -1339,7 +1339,9 @@ class CodeForgeCommandHandlers {
       const containerPort = 2000;
 
       // Build gdbserver command
-      const gdbserverCommand = `gdbserver 0.0.0.0:${containerPort} ${containerFuzzerPath} ${containerCrashPath}`;
+      // Use --once to exit after first connection, and --attach would require PID
+      // Instead, we'll use the standard mode but the program will wait for continue
+      const gdbserverCommand = `gdbserver --once 0.0.0.0:${containerPort} ${containerFuzzerPath} ${containerCrashPath}`;
 
       // Get configuration
       const config = vscode.workspace.getConfiguration("codeforge");
@@ -1449,13 +1451,12 @@ class CodeForgeCommandHandlers {
               // Configure GDB for remote debugging
               "set confirm off",
               "set breakpoint pending on",
-              // Set temporary breakpoint at main and continue to it
-              "tbreak main",
-              "continue",
+              // Note: reverse debugging (target record-full) is not enabled
+              // as it significantly degrades performance
             ],
             valuesFormatting: "parseText",
             printCalls: false,
-            stopAtConnect: false,
+            stopAtConnect: true,
           },
         );
 

--- a/test/suite/gdb-integration.test.js
+++ b/test/suite/gdb-integration.test.js
@@ -1311,7 +1311,7 @@ suite("GDB Integration Test Suite", () => {
 
       assert.strictEqual(
         result.gdbserverCommand,
-        `gdbserver 0.0.0.0:2000 ${containerFuzzerPath} ${containerCrashPath}`,
+        `gdbserver --once 0.0.0.0:2000 ${containerFuzzerPath} ${containerCrashPath}`,
       );
     });
   });


### PR DESCRIPTION
Fixed issues where GDB client would throw errors when connecting to gdbserver:
- "Cannot execute this command while the target is running" (thread-info)
- "Selected thread is running" (stack-info-depth)

Changes:
- Set stopAtConnect to true in launch configuration to ensure target is properly stopped on connection
- Removed premature tbreak/continue commands from autorun that caused target to run before debugger was ready
- Added --once flag to gdbserver for cleaner session lifecycle
- Added note about reverse debugging being disabled for performance reasons

The debugger now connects smoothly and the target is in a stopped state, ready for setting breakpoints and debugging.