### PR TITLE
chore: bump version to 0.1.2 and update documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.1.2] - 2025-10-08
+
+### Added
+
+- **Automatic GDB Launch Configuration**: Auto-creates and manages VS Code launch.json configurations for crash debugging with gdbserver
+- **Regenerate Fuzzer List Command**: New command to clear cached fuzzer list and regenerate from CMake presets
+- **Filesystem-Based Crash Counting**: Accurate tracking of new crashes by counting crash files before and after fuzzing sessions
+- **Enhanced Script Installation**: All fuzzing scripts (build, find, run, crashes, backtrace, clear) are now packaged and installed during initialization
+
+### Enhanced
+
+- **Improved Terminal Output**: Enhanced fuzzing terminal with aligned status boxes and separate crash information display
+- **Better Crash File Handling**: Crash viewer now reads only needed bytes (64KB) instead of entire files, preventing VSCode 50MB limit issues
+- **Smarter Output Channel Behavior**: Output channel only auto-shows for errors or user-requested actions, reducing noise
+- **Refresh Button Behavior**: Refresh button now bypasses cache to always fetch fresh data and prevents UI duplication
+
+### Fixed
+
+- **GDB Remote Debugging**: Resolved threading and stack trace errors when connecting to gdbserver
+  - Fixed "Cannot execute this command while the target is running" error
+  - Fixed "Selected thread is running" error
+  - Added stopAtConnect configuration for proper target state on connection
+- **Terminal Error Handling**: Terminal now stays open on fuzzer build errors with key-to-close prompt for better error visibility
+- **Initialization Check**: Fuzzer refresh command now validates CodeForge initialization before attempting discovery
+- **Command Registration Cleanup**: Removed unsupported commands from package.json, resolving "command not found" errors
+
+### Technical
+
+- **Launch Configuration Management**: New LaunchConfigManager utility for managing launch.json with JSON comment support
+- **Crash Counting Logic**: Per-fuzzer statistics showing "X new (Y total)" crashes
+- **GDB Session Lifecycle**: Improved gdbserver session handling with --once flag and proper connection sequence
+- **Script Verification**: InitializationDetectionService now verifies all 6 scripts are present with executable permissions
+
 ## [0.1.1] - 2025-10-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -368,6 +368,31 @@ For complete configuration documentation, parameter reference, validation rules,
 
 ## Release Notes
 
+### 0.1.2
+
+Incremental release focused on crash debugging workflow improvements and terminal enhancements:
+
+#### New Features
+
+- **Automatic GDB Launch Configuration**: Seamless crash debugging with auto-generated VS Code launch configurations for gdbserver
+- **Regenerate Fuzzer List**: New command to refresh fuzzer cache and regenerate from CMake presets
+- **Accurate Crash Counting**: Filesystem-based crash tracking that counts new crashes per fuzzing session
+- **Complete Script Installation**: All 6 fuzzing scripts are now automatically packaged and verified during initialization
+
+#### Improvements
+
+- **Enhanced Terminal Output**: Improved fuzzing terminal with properly aligned status boxes and clear crash statistics
+- **Optimized Crash Viewing**: Crash viewer now reads only 64KB chunks, avoiding VSCode's 50MB file limit
+- **Refined Output Channel**: Output channel only appears for errors or user actions, reducing UI noise
+- **Better Refresh Behavior**: Refresh button bypasses cache for accurate data and prevents duplicate UI entries
+
+#### Bug Fixes
+
+- **GDB Remote Debugging**: Fixed threading and stack trace errors during gdbserver connections
+- **Terminal Error Display**: Terminals stay open on build errors with clear error messages
+- **Initialization Validation**: Fuzzer refresh now checks initialization state before attempting discovery
+- **Command Registration**: Cleaned up package.json to remove unsupported commands
+
 ### 0.1.1
 
 Incremental feature release with enhanced debugging, corpus management, and improved user control:

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "CodeForge",
   "description": "Docker container management for development environments",
   "publisher": "TulipTreeTechnology",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "icon": "media/icon.png",
   "engines": {
     "vscode": "^1.103.0"


### PR DESCRIPTION
Update version to 0.1.2 with comprehensive changelog and readme updates covering:
- Automatic GDB launch configuration management
- Regenerate fuzzer list command
- Filesystem-based crash counting
- Enhanced script installation and verification
- Improved terminal output and crash file handling
- GDB remote debugging fixes
- Terminal error handling improvements
- Command registration cleanup