### PR TITLE
chore: update Docker images to main-609e0ab

### DIFF
--- a/src/utils/projectTypeDetector.js
+++ b/src/utils/projectTypeDetector.js
@@ -14,8 +14,8 @@ const PROJECT_TYPES = {
  * Docker images for each project type
  */
 const PROJECT_TYPE_IMAGES = {
-  [PROJECT_TYPES.CMAKE]: "ghcr.io/tuliptreetech/codeforge-cmake:main-872ac55",
-  [PROJECT_TYPES.RUST]: "ghcr.io/tuliptreetech/codeforge-rust:main-872ac55",
+  [PROJECT_TYPES.CMAKE]: "ghcr.io/tuliptreetech/codeforge-cmake:main-609e0ab",
+  [PROJECT_TYPES.RUST]: "ghcr.io/tuliptreetech/codeforge-rust:main-609e0ab",
 };
 
 /**


### PR DESCRIPTION
Update CMAKE and RUST project type Docker images from main-872ac55 to main-609e0ab to incorporate latest improvements and fixes.